### PR TITLE
chore: Quote 3.10 so GHA doesn't interpret it as 3.1

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install poetry
         run: pipx install poetry

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-python@v5
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install poetry
         if: ${{ steps.release.outputs.releases_created == 'true' }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts workflow YAML to ensure `actions/setup-python` uses Python 3.10 correctly, with no product/runtime code changes.
> 
> **Overview**
> Updates the `manual-publish` and `release-please` GitHub Actions workflows to quote the `python-version` value (`"3.10"`) so YAML parsing doesn’t misinterpret it (e.g., as `3.1`) during CI/release publishing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f00b012c2af2a75f8b7905013f20ae1dccd544d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->